### PR TITLE
[codex] Remove Renovate auto-merge hooks

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,16 +26,3 @@ jobs:
       - name: Run tests
         run: task test
 
-  automerge:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event.pull_request.user.login == 'renovate[bot]'
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: automerge
-        uses: pascalgn/automerge-action@v0.16.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_LABELS: ""


### PR DESCRIPTION
## Summary
- remove explicit CI jobs that merge Renovate pull requests
- stop adding the `automerge` label from Renovate config

## Validation
- inspected the resulting diff for the touched CI and Renovate config files
